### PR TITLE
#3 Update Android Gradle Plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
-        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.android.tools.build:gradle:4.1.1'
         classpath "org.jetbrains.dokka:dokka-android-gradle-plugin:$dokka_version"
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ kotlin.incremental.multiplatform = true
 android.useAndroidX=true
 android.enableJetifier=true
 
-kotlin_version = 1.3.40
+kotlin_version = 1.4.21
 
 serialization_version = 0.11.1
 ktor_version = 1.2.2
@@ -14,7 +14,7 @@ dokka_version = 0.9.18
 corektx_version = 1.1.0-rc01
 appcompat_version = 1.1.0-beta01
 recyclerview_version = 1.0.0
-constraintlayout_version = 2.0.0-beta2
+constraintlayout_version = 2.0.4
 material_version = 1.0.0
 
 klock_version = 1.4.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jun 20 22:19:11 PDT 2019
+#Tue Dec 08 23:12:53 GMT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip


### PR DESCRIPTION
- Updating the Android Gradle Plugin also required updating the Gradle Wrapper and the ConstraintLayout lib as resource merging errors were being thrown during build.
- AS's static analysis insisted that I update the version of Kotlin used to match AS.